### PR TITLE
Support adding & removing peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,10 @@ HTTP API
 - GET `/logs/dbserver` returns the contents of the dbserver log file.
 - GET `/logs/coordinator` returns the contents of the coordinator log file.
 - GET `/version` returns a JSON object with the version & build information. 
-- POST `/shutdown` initiates a shutdown of the process and all servers started by it.
+- POST `/shutdown` initiates a shutdown of the process and all servers started by it. 
+  (passing a `mode=goodbye` query to the URL makes the peer say goodbye to the master).
 - GET `/hello` internal API used to join a master. Not for external use.
+- POST `/goodbye` internal API used to leave a master for good. Not for external use.
 
 Future plans
 ------------

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 		Run:   cmdMainRun,
 	}
 	log               = logging.MustGetLogger(projectName)
+	id                string
 	agencySize        int
 	arangodExecutable string
 	arangodJSstartup  string
@@ -57,6 +58,7 @@ var (
 func init() {
 	f := cmdMain.Flags()
 	f.IntVar(&agencySize, "agencySize", 3, "Number of agents in the cluster")
+	f.StringVar(&id, "id", "", "Unique identifier of this peer")
 	f.StringVar(&arangodExecutable, "arangod", "/usr/sbin/arangod", "Path of arangod")
 	f.StringVar(&arangodJSstartup, "jsDir", "/usr/share/arangodb3/js", "Path of arango JS")
 	f.IntVar(&masterPort, "masterPort", 4000, "Port to listen on for other arangodb's to join")
@@ -195,6 +197,7 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 
 	// Create service
 	service, err := service.NewService(log, service.ServiceConfig{
+		ID:                id,
 		AgencySize:        agencySize,
 		ArangodExecutable: arangodExecutable,
 		ArangodJSstartup:  arangodJSstartup,

--- a/service/docker.go
+++ b/service/docker.go
@@ -9,23 +9,28 @@ import (
 
 // findDockerExposedAddress looks up the external port number to which the given
 // port is mapped onto for the given container.
-func findDockerExposedAddress(dockerEndpoint, containerName string, port int) (int, error) {
+func findDockerExposedAddress(dockerEndpoint, containerName string, port int) (hostPort int, isNetHost bool, err error) {
 	client, err := docker.NewClient(dockerEndpoint)
 	if err != nil {
-		return 0, maskAny(err)
+		return 0, false, maskAny(err)
 	}
 	container, err := client.InspectContainer(containerName)
 	if err != nil {
-		return 0, maskAny(err)
+		return 0, false, maskAny(err)
+	}
+	isNetHost = container.HostConfig.NetworkMode == "host"
+	if isNetHost {
+		// There is no port mapping for `--net=host`
+		return port, isNetHost, nil
 	}
 	dockerPort := docker.Port(fmt.Sprintf("%d/tcp", port))
 	bindings, ok := container.NetworkSettings.Ports[dockerPort]
 	if !ok || len(bindings) == 0 {
-		return 0, maskAny(fmt.Errorf("Cannot find port binding for TCP port %d", port))
+		return 0, isNetHost, maskAny(fmt.Errorf("Cannot find port binding for TCP port %d", port))
 	}
-	hostPort, err := strconv.Atoi(bindings[0].HostPort)
+	hostPort, err = strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
-		return 0, maskAny(err)
+		return 0, isNetHost, maskAny(err)
 	}
-	return hostPort, nil
+	return hostPort, isNetHost, nil
 }

--- a/service/master.go
+++ b/service/master.go
@@ -11,19 +11,20 @@ func (s *Service) startMaster(runner Runner) {
 	s.startHTTPServer()
 
 	// Permanent loop:
-	s.log.Infof("Serving as master on %s:%d...", s.OwnAddress, s.announcePort)
+	s.log.Infof("Serving as master with ID '%s' on %s:%d...", s.ID, s.OwnAddress, s.announcePort)
 
 	if s.AgencySize == 1 {
 		s.myPeers.Peers = []Peer{
 			Peer{
+				ID:         s.ID,
 				Address:    s.OwnAddress,
 				Port:       s.announcePort,
 				PortOffset: 0,
 				DataDir:    s.DataDir,
+				HasAgent:   true,
 			},
 		}
 		s.myPeers.AgencySize = s.AgencySize
-		s.myPeers.MyIndex = 0
 		s.saveSetup()
 		s.log.Info("Starting service...")
 		s.startRunning(runner)
@@ -43,7 +44,7 @@ func (s *Service) startMaster(runner Runner) {
 	for {
 		time.Sleep(time.Second)
 		select {
-		case <-s.starter:
+		case <-s.startRunningWaiter.Done():
 			s.saveSetup()
 			s.log.Info("Starting service...")
 			s.startRunning(runner)

--- a/service/peers.go
+++ b/service/peers.go
@@ -1,0 +1,69 @@
+package service
+
+type Peer struct {
+	ID         string // Unique of of the peer
+	Address    string // IP address of arangodb peer server
+	Port       int    // Port number of arangodb peer server
+	PortOffset int    // Offset to add to base ports for the various servers (agent, coordinator, dbserver)
+	DataDir    string // Directory holding my data
+	HasAgent   bool   // If set, this peer is running an agent
+}
+
+// Peer information.
+// When this type (or any of the types used in here) is changed, increase `SetupConfigVersion`.
+type peers struct {
+	Peers      []Peer // All peers (index 0 is reserver for the master)
+	AgencySize int    // Number of agents
+}
+
+// PeerByID returns a peer with given id & true, or false if not found.
+func (p peers) PeerByID(id string) (Peer, bool) {
+	for _, x := range p.Peers {
+		if x.ID == id {
+			return x, true
+		}
+	}
+	return Peer{}, false
+}
+
+// RemovePeerByID removes the peer with given ID.
+func (p *peers) RemovePeerByID(id string) bool {
+	newPeers := make([]Peer, 0, len(p.Peers))
+	found := false
+	for _, x := range p.Peers {
+		if x.ID != id {
+			newPeers = append(newPeers, x)
+		} else {
+			found = true
+		}
+	}
+	p.Peers = newPeers
+	return found
+}
+
+// IDs returns the IDs of all peers.
+func (p peers) IDs() []string {
+	list := make([]string, 0, len(p.Peers))
+	for _, x := range p.Peers {
+		list = append(list, x.ID)
+	}
+	return list
+}
+
+// GetFreePortOffset returns the first unallocated port offset.
+func (p peers) GetFreePortOffset() int {
+	portOffset := 0
+	for {
+		found := false
+		for _, p := range p.Peers {
+			if p.PortOffset == portOffset {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return portOffset
+		}
+		portOffset += portOffsetIncrement
+	}
+}

--- a/service/server.go
+++ b/service/server.go
@@ -10,10 +10,15 @@ import (
 	"path/filepath"
 )
 
-type SlaveRequest struct {
+type HelloRequest struct {
+	SlaveID      string // Unique ID of the slave
 	SlaveAddress string // Address used to reach the slave (if empty, this will be derived from the request)
 	SlavePort    int    // Port used to reach the slave
 	DataDir      string // Directory used for data by this slave
+}
+
+type GoodbyeRequest struct {
+	SlaveID string // Unique ID of the slave that should be removed.
 }
 
 type ProcessListResponse struct {
@@ -38,6 +43,7 @@ type ServerProcess struct {
 // If will return directly after starting it.
 func (s *Service) startHTTPServer() {
 	http.HandleFunc("/hello", s.helloHandler)
+	http.HandleFunc("/goodbye", s.goodbyeHandler)
 	http.HandleFunc("/process", s.processListHandler)
 	http.HandleFunc("/logs/agent", s.agentLogsHandler)
 	http.HandleFunc("/logs/dbserver", s.dbserverLogsHandler)
@@ -46,7 +52,10 @@ func (s *Service) startHTTPServer() {
 	http.HandleFunc("/shutdown", s.shutdownHandler)
 
 	go func() {
-		containerPort, hostPort := s.getHTTPServerPort()
+		containerPort, hostPort, err := s.getHTTPServerPort()
+		if err != nil {
+			s.log.Fatalf("Failed to get HTTP port info: %#v", err)
+		}
 		addr := fmt.Sprintf("0.0.0.0:%d", containerPort)
 		s.log.Infof("Listening on %s (%s:%d)", addr, s.OwnAddress, hostPort)
 		if err := http.ListenAndServe(addr, nil); err != nil {
@@ -78,24 +87,32 @@ func (s *Service) helloHandler(w http.ResponseWriter, r *http.Request) {
 	// Learn my own address (if needed)
 	if len(s.myPeers.Peers) == 0 {
 		myself := findHost(r.Host)
-		_, hostPort := s.getHTTPServerPort()
+		_, hostPort, _ := s.getHTTPServerPort()
 		s.myPeers.Peers = []Peer{
 			Peer{
+				ID:         s.ID,
 				Address:    myself,
 				Port:       hostPort,
 				PortOffset: 0,
 				DataDir:    s.DataDir,
+				HasAgent:   true,
 			},
 		}
 		s.myPeers.AgencySize = s.AgencySize
-		s.myPeers.MyIndex = 0
 	}
 
 	if r.Method == "POST" {
-		var req SlaveRequest
+		var req HelloRequest
 		defer r.Body.Close()
-		body, _ := ioutil.ReadAll(r.Body)
-		json.Unmarshal(body, &req)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Cannot read request body: %v", err.Error()))
+			return
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Cannot parse request body: %v", err.Error()))
+			return
+		}
 
 		slaveAddr := req.SlaveAddress
 		if slaveAddr == "" {
@@ -103,25 +120,48 @@ func (s *Service) helloHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		slavePort := req.SlavePort
 
+		// Check request
+		if req.SlaveID == "" {
+			writeError(w, http.StatusBadRequest, "SlaveID must be set.")
+			return
+		}
+
+		// Check datadir
 		if !s.allowSameDataDir {
 			for _, p := range s.myPeers.Peers {
-				if p.Address == slaveAddr && p.DataDir == req.DataDir {
+				if p.Address == slaveAddr && p.DataDir == req.DataDir && p.ID != req.SlaveID {
 					writeError(w, http.StatusBadRequest, "Cannot use same directory as peer.")
 					return
 				}
 			}
 		}
 
-		newPeer := Peer{
-			Address:    slaveAddr,
-			Port:       slavePort,
-			PortOffset: len(s.myPeers.Peers) * portOffsetIncrement,
-			DataDir:    req.DataDir,
-		}
-		s.myPeers.Peers = append(s.myPeers.Peers, newPeer)
-		s.log.Infof("New peer: %s, portOffset: %d", newPeer.Address, newPeer.PortOffset)
-		if len(s.myPeers.Peers) == s.AgencySize {
-			s.starter <- true
+		// If slaveID already known, then return data right away.
+		_, idFound := s.myPeers.PeerByID(req.SlaveID)
+		if idFound {
+			// ID already found, update peer data
+			for i, p := range s.myPeers.Peers {
+				if p.ID == req.SlaveID {
+					s.myPeers.Peers[i].Port = req.SlavePort
+					s.myPeers.Peers[i].Address = req.SlaveAddress
+					s.myPeers.Peers[i].DataDir = req.DataDir
+				}
+			}
+		} else {
+			// ID not yet found, add it
+			newPeer := Peer{
+				ID:         req.SlaveID,
+				Address:    slaveAddr,
+				Port:       slavePort,
+				PortOffset: s.myPeers.GetFreePortOffset(),
+				DataDir:    req.DataDir,
+				HasAgent:   len(s.myPeers.Peers) < s.AgencySize,
+			}
+			s.myPeers.Peers = append(s.myPeers.Peers, newPeer)
+			s.log.Infof("Added new peer '%s': %s, portOffset: %d", newPeer.ID, newPeer.Address, newPeer.PortOffset)
+			if len(s.myPeers.Peers) == s.AgencySize {
+				s.startRunningTrigger()
+			}
 		}
 	}
 	b, err := json.Marshal(s.myPeers)
@@ -132,15 +172,63 @@ func (s *Service) helloHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// goodbyeHandler handles a `/goodbye` request that removes a peer from the list of peers.
+func (s *Service) goodbyeHandler(w http.ResponseWriter, r *http.Request) {
+	// Claim exclusive access to our data structures
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if r.Method != "POST" {
+		writeError(w, http.StatusMethodNotAllowed, "POST required")
+		return
+	}
+	var req GoodbyeRequest
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("Cannot read request body: %v", err.Error()))
+		return
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("Cannot parse request body: %v", err.Error()))
+		return
+	}
+
+	// Check request
+	if req.SlaveID == "" {
+		writeError(w, http.StatusBadRequest, "SlaveID must be set.")
+		return
+	}
+
+	// Remove the peer
+	s.log.Infof("Removing peer %s", req.SlaveID)
+	if removed := s.myPeers.RemovePeerByID(req.SlaveID); !removed {
+		// ID not found
+		writeError(w, http.StatusNotFound, "Unknown ID")
+		return
+	}
+
+	// Peer has been removed, update stored config
+	s.log.Info("Saving setup")
+	if err := s.saveSetup(); err != nil {
+		s.log.Errorf("Failed to save setup: %#v", err)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("BYE"))
+}
+
 func (s *Service) processListHandler(w http.ResponseWriter, r *http.Request) {
 	// Gather processes
 	resp := ProcessListResponse{}
-	peers := s.myPeers.Peers
-	index := s.myPeers.MyIndex
-	if index < len(peers) {
-		p := peers[index]
-		portOffset := p.PortOffset
-		ip := p.Address
+	expectedServers := 2
+	myPeer, found := s.myPeers.PeerByID(s.ID)
+	if found {
+		portOffset := myPeer.PortOffset
+		ip := myPeer.Address
+		if myPeer.HasAgent {
+			expectedServers = 3
+		}
 		if p := s.servers.agentProc; p != nil {
 			resp.Servers = append(resp.Servers, ServerProcess{
 				Type:        "agent",
@@ -168,10 +256,6 @@ func (s *Service) processListHandler(w http.ResponseWriter, r *http.Request) {
 				ContainerID: p.ContainerID(),
 			})
 		}
-	}
-	expectedServers := 2
-	if s.needsAgent() {
-		expectedServers = 3
 	}
 	resp.ServersStarted = len(resp.Servers) == expectedServers
 	b, err := json.Marshal(resp)
@@ -203,13 +287,14 @@ func (s *Service) coordinatorLogsHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Service) logsHandler(w http.ResponseWriter, r *http.Request, mode string, serverPortOffset int) {
-	if s.myPeers.MyIndex < 0 || s.myPeers.MyIndex >= len(s.myPeers.Peers) {
+	myPeer, found := s.myPeers.PeerByID(s.ID)
+	if !found {
 		// Not ready yet
 		w.WriteHeader(http.StatusPreconditionFailed)
 		return
 	}
 	// Find log path
-	portOffset := s.myPeers.Peers[s.myPeers.MyIndex].PortOffset
+	portOffset := myPeer.PortOffset
 	myPort := s.MasterPort + portOffset + serverPortOffset
 	logPath := filepath.Join(s.DataDir, fmt.Sprintf("%s%d", mode, myPort), "arangod.log")
 	s.log.Debugf("Fetching logs in %s", logPath)
@@ -250,11 +335,22 @@ func (s *Service) versionHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Service) shutdownHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
-	} else {
-		s.cancel()
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		return
 	}
+
+	if r.FormValue("mode") == "goodbye" {
+		// Inform the master we're leaving for good
+		if err := s.sendMasterGoodbye(); err != nil {
+			s.log.Errorf("Failed to send master goodbye: %#v", err)
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	// Stop my services
+	s.cancel()
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
@@ -267,14 +363,18 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	w.Write(b)
 }
 
-func (s *Service) getHTTPServerPort() (containerPort, hostPort int) {
+func (s *Service) getHTTPServerPort() (containerPort, hostPort int, err error) {
 	containerPort = s.MasterPort
 	hostPort = s.announcePort
 	if s.announcePort == s.MasterPort && len(s.myPeers.Peers) > 0 {
-		containerPort += s.myPeers.Peers[s.myPeers.MyIndex].PortOffset
+		if myPeer, ok := s.myPeers.PeerByID(s.ID); ok {
+			containerPort += myPeer.PortOffset
+		} else {
+			return 0, 0, maskAny(fmt.Errorf("No peer information found for ID '%s'", s.ID))
+		}
 	}
 	if s.isNetHost {
 		hostPort = containerPort
 	}
-	return containerPort, hostPort
+	return containerPort, hostPort, nil
 }

--- a/service/setup_config.go
+++ b/service/setup_config.go
@@ -8,13 +8,14 @@ import (
 
 const (
 	// Version of the process that created this. If the structure or semantics changed, you must increase this version.
-	SetupConfigVersion = "0.1.0"
+	SetupConfigVersion = "0.1.1"
 	setupFileName      = "setup.json"
 )
 
 // SetupConfigFile is the JSON structure stored in the setup file of this process.
 type SetupConfigFile struct {
 	Version string `json:"version"` // Version of the process that created this. If the structure or semantics changed, you must increase this version.
+	ID      string `json:"id"`      // My unique peer ID
 	Peers   peers  `json:"peers"`
 }
 
@@ -22,6 +23,7 @@ type SetupConfigFile struct {
 func (s *Service) saveSetup() error {
 	cfg := SetupConfigFile{
 		Version: SetupConfigVersion,
+		ID:      s.ID,
 		Peers:   s.myPeers,
 	}
 	b, err := json.Marshal(cfg)
@@ -46,8 +48,9 @@ func (s *Service) relaunch(runner Runner) bool {
 		if err := json.Unmarshal(setupContent, &cfg); err == nil {
 			if cfg.Version == SetupConfigVersion {
 				s.myPeers = cfg.Peers
+				s.ID = cfg.ID
 				s.AgencySize = s.myPeers.AgencySize
-				s.log.Infof("Relaunching service on %s:%d...", s.OwnAddress, s.announcePort)
+				s.log.Infof("Relaunching service with id '%s' on %s:%d...", s.ID, s.OwnAddress, s.announcePort)
 				s.startHTTPServer()
 				s.startRunning(runner)
 				return true


### PR DESCRIPTION
This PR replaces the old index based way of getting information out of the list of peers.

This has been replaced with an ID based retrieval of information.
This is needed to support removing peers and adding new ones later (and re-using port ranges)