### PR TITLE
Change PortOffset allocation to be unique per address, not globally unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ debugging only.
 
 show more information (default false).
 
+* `--uniquePortOffsets bool`
+
+If set to true, all port offsets (of slaves) will be made globally unique.
+By default (value is false), port offsets will be unique per slave address.
+
 * `--dockerUser user`
 
 `user` is an expression to be used for `docker run` with the `--user` 

--- a/main.go
+++ b/main.go
@@ -32,27 +32,28 @@ var (
 		Short: "Start ArangoDB clusters with ease",
 		Run:   cmdMainRun,
 	}
-	log               = logging.MustGetLogger(projectName)
-	id                string
-	agencySize        int
-	arangodExecutable string
-	arangodJSstartup  string
-	masterPort        int
-	rrPath            string
-	startCoordinator  bool
-	startDBserver     bool
-	dataDir           string
-	ownAddress        string
-	masterAddress     string
-	verbose           bool
-	serverThreads     int
-	dockerEndpoint    string
-	dockerImage       string
-	dockerUser        string
-	dockerContainer   string
-	dockerGCDelay     time.Duration
-	dockerNetHost     bool
-	dockerPrivileged  bool
+	log                  = logging.MustGetLogger(projectName)
+	id                   string
+	agencySize           int
+	arangodExecutable    string
+	arangodJSstartup     string
+	masterPort           int
+	rrPath               string
+	startCoordinator     bool
+	startDBserver        bool
+	dataDir              string
+	ownAddress           string
+	masterAddress        string
+	verbose              bool
+	serverThreads        int
+	allPortOffsetsUnique bool
+	dockerEndpoint       string
+	dockerImage          string
+	dockerUser           string
+	dockerContainer      string
+	dockerGCDelay        time.Duration
+	dockerNetHost        bool
+	dockerPrivileged     bool
 )
 
 func init() {
@@ -77,6 +78,7 @@ func init() {
 	f.DurationVar(&dockerGCDelay, "dockerGCDelay", defaultDockerGCDelay, "Delay before stopped containers are garbage collected")
 	f.BoolVar(&dockerNetHost, "dockerNetHost", false, "Run containers with --net=host")
 	f.BoolVar(&dockerPrivileged, "dockerPrivileged", false, "Run containers with --privileged")
+	f.BoolVar(&allPortOffsetsUnique, "uniquePortOffsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
 }
 
 // handleSignal listens for termination signals and stops this process onup termination.
@@ -197,29 +199,30 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 
 	// Create service
 	service, err := service.NewService(log, service.ServiceConfig{
-		ID:                id,
-		AgencySize:        agencySize,
-		ArangodExecutable: arangodExecutable,
-		ArangodJSstartup:  arangodJSstartup,
-		MasterPort:        masterPort,
-		RrPath:            rrPath,
-		StartCoordinator:  startCoordinator,
-		StartDBserver:     startDBserver,
-		DataDir:           dataDir,
-		OwnAddress:        ownAddress,
-		MasterAddress:     masterAddress,
-		Verbose:           verbose,
-		ServerThreads:     serverThreads,
-		RunningInDocker:   os.Getenv("RUNNING_IN_DOCKER") == "true",
-		DockerContainer:   dockerContainer,
-		DockerEndpoint:    dockerEndpoint,
-		DockerImage:       dockerImage,
-		DockerUser:        dockerUser,
-		DockerGCDelay:     dockerGCDelay,
-		DockerNetHost:     dockerNetHost,
-		DockerPrivileged:  dockerPrivileged,
-		ProjectVersion:    projectVersion,
-		ProjectBuild:      projectBuild,
+		ID:                   id,
+		AgencySize:           agencySize,
+		ArangodExecutable:    arangodExecutable,
+		ArangodJSstartup:     arangodJSstartup,
+		MasterPort:           masterPort,
+		RrPath:               rrPath,
+		StartCoordinator:     startCoordinator,
+		StartDBserver:        startDBserver,
+		DataDir:              dataDir,
+		OwnAddress:           ownAddress,
+		MasterAddress:        masterAddress,
+		Verbose:              verbose,
+		ServerThreads:        serverThreads,
+		AllPortOffsetsUnique: allPortOffsetsUnique,
+		RunningInDocker:      os.Getenv("RUNNING_IN_DOCKER") == "true",
+		DockerContainer:      dockerContainer,
+		DockerEndpoint:       dockerEndpoint,
+		DockerImage:          dockerImage,
+		DockerUser:           dockerUser,
+		DockerGCDelay:        dockerGCDelay,
+		DockerNetHost:        dockerNetHost,
+		DockerPrivileged:     dockerPrivileged,
+		ProjectVersion:       projectVersion,
+		ProjectBuild:         projectBuild,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create service: %#v", err)

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -19,19 +19,20 @@ import (
 )
 
 type ServiceConfig struct {
-	ID                string // Unique identifier of this peer
-	AgencySize        int
-	ArangodExecutable string
-	ArangodJSstartup  string
-	MasterPort        int
-	RrPath            string
-	StartCoordinator  bool
-	StartDBserver     bool
-	DataDir           string
-	OwnAddress        string // IP address of used to reach this process
-	MasterAddress     string
-	Verbose           bool
-	ServerThreads     int // If set to something other than 0, this will be added to the commandline of each server with `--server.threads`...
+	ID                   string // Unique identifier of this peer
+	AgencySize           int
+	ArangodExecutable    string
+	ArangodJSstartup     string
+	MasterPort           int
+	RrPath               string
+	StartCoordinator     bool
+	StartDBserver        bool
+	DataDir              string
+	OwnAddress           string // IP address of used to reach this process
+	MasterAddress        string
+	Verbose              bool
+	ServerThreads        int  // If set to something other than 0, this will be added to the commandline of each server with `--server.threads`...
+	AllPortOffsetsUnique bool // If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.
 
 	DockerContainer  string // Name of the container running this process
 	DockerEndpoint   string // Where to reach the docker daemon

--- a/service/peers.go
+++ b/service/peers.go
@@ -51,14 +51,16 @@ func (p peers) IDs() []string {
 }
 
 // GetFreePortOffset returns the first unallocated port offset.
-func (p peers) GetFreePortOffset() int {
+func (p peers) GetFreePortOffset(peerAddress string, allPortOffsetsUnique bool) int {
 	portOffset := 0
 	for {
 		found := false
 		for _, p := range p.Peers {
 			if p.PortOffset == portOffset {
-				found = true
-				break
+				if allPortOffsetsUnique || p.Address == peerAddress {
+					found = true
+					break
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
Fixes #3 

The result of this PR is shown in the list below.
4 starters are running on 3 different machines.

```
{
  "Peers": [
    {
      "ID": "44dfdef4",
      "Address": "192.168.10.4",
      "Port": 7000,
      "PortOffset": 0,
      "DataDir": "/data",
      "HasAgent": true
    },
    {
      "ID": "e36d77ed",
      "Address": "192.168.10.5",
      "Port": 7000,
      "PortOffset": 0,
      "DataDir": "/data",
      "HasAgent": true
    },
    {
      "ID": "c3156e37",
      "Address": "192.168.10.6",
      "Port": 7000,
      "PortOffset": 0,
      "DataDir": "/data",
      "HasAgent": true
    },
    {
      "ID": "4aba1a9b",
      "Address": "192.168.10.4",
      "Port": 7100,
      "PortOffset": 5,
      "DataDir": "/data",
      "HasAgent": false
    }
  ],
  "AgencySize": 3
}
```

# Override new behavior 

Using the `--uniquePortOffsets` flag you can override the new behavior and force all port offsets to be globally unique.