### PR TITLE
Attach to running servers

### DIFF
--- a/service/runner.go
+++ b/service/runner.go
@@ -7,8 +7,18 @@ type Volume struct {
 }
 
 type Runner interface {
+	// Map the given host directory to a container directory
 	GetContainerDir(hostDir string) string
-	Start(command string, args []string, volumes []Volume, ports []int, containerName string) (Process, error)
+
+	// GetRunningServer checks if there is already a server process running in the given server directory.
+	// If that is the case, its process is returned.
+	// Otherwise nil is returned.
+	GetRunningServer(serverDir string) (Process, error)
+
+	// Start a server with given arguments
+	Start(command string, args []string, volumes []Volume, ports []int, containerName, serverDir string) (Process, error)
+
+	// Create a command that a user should use to start a slave arangodb instance.
 	CreateStartArangodbCommand(index int, masterIP string, masterPort string) string
 
 	// Cleanup after all processes are dead and have been cleaned themselves

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -2,7 +2,11 @@ package service
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"syscall"
 )
 
@@ -16,19 +20,47 @@ type processRunner struct {
 }
 
 type process struct {
-	cmd *exec.Cmd
+	p *os.Process
 }
 
 func (r *processRunner) GetContainerDir(hostDir string) string {
 	return hostDir
 }
 
-func (r *processRunner) Start(command string, args []string, volumes []Volume, ports []int, containerName string) (Process, error) {
+// GetRunningServer checks if there is already a server process running in the given server directory.
+// If that is the case, its process is returned.
+// Otherwise nil is returned.
+func (r *processRunner) GetRunningServer(serverDir string) (Process, error) {
+	lockContent, err := ioutil.ReadFile(filepath.Join(serverDir, "data", "LOCK"))
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, maskAny(err)
+	}
+	pid, err := strconv.Atoi(string(lockContent))
+	if err != nil {
+		// No valid contents in LOCK file
+		return nil, nil
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		// Cannot find pid
+		return nil, nil
+	}
+	if err := p.Signal(syscall.Signal(0)); err != nil {
+		// Process does not seem to exist anymore
+		return nil, nil
+	}
+	// Apparently we still have a server.
+	return &process{p}, nil
+}
+
+func (r *processRunner) Start(command string, args []string, volumes []Volume, ports []int, containerName, serverDir string) (Process, error) {
 	c := exec.Command(command, args...)
 	if err := c.Start(); err != nil {
 		return nil, maskAny(err)
 	}
-	return &process{c}, nil
+	return &process{c.Process}, nil
 }
 
 func (r *processRunner) CreateStartArangodbCommand(index int, masterIP string, masterPort string) string {
@@ -50,7 +82,7 @@ func (r *processRunner) Cleanup() error {
 
 // ProcessID returns the pid of the process (if not running in docker)
 func (p *process) ProcessID() int {
-	proc := p.cmd.Process
+	proc := p.p
 	if proc != nil {
 		return proc.Pid
 	}
@@ -68,14 +100,14 @@ func (p *process) ContainerIP() string {
 }
 
 func (p *process) Wait() {
-	proc := p.cmd.Process
+	proc := p.p
 	if proc != nil {
 		proc.Wait()
 	}
 }
 
 func (p *process) Terminate() error {
-	proc := p.cmd.Process
+	proc := p.p
 	if proc != nil {
 		if err := proc.Signal(syscall.SIGTERM); err != nil {
 			return maskAny(err)
@@ -85,7 +117,7 @@ func (p *process) Terminate() error {
 }
 
 func (p *process) Kill() error {
-	proc := p.cmd.Process
+	proc := p.p
 	if proc != nil {
 		if err := proc.Kill(); err != nil {
 			return maskAny(err)


### PR DESCRIPTION
Fixes #6

When the `arangodb` starter fails (`kill -9`, ...) and you restart it, it did try to start servers which would fail because there were already servers running on the allocated ports.

This PR changes that. The starter will first check if a server process is already running and if so, attach to that. When no valid (running) server can be found, it will start new servers.