### PR TITLE
Various IPv6 fixes

### DIFF
--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -161,7 +161,7 @@ var confFileTemplate = `# ArangoDB configuration file
 #
 
 [server]
-endpoint = tcp://0.0.0.0:%s
+endpoint = tcp://[::]:%s
 threads = %d
 
 [log]

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -116,17 +116,11 @@ const (
 
 // A helper function:
 
-func normalizeHost(address string) string {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		host = strings.Split(address, ":")[0]
-	}
+func normalizeHostName(host string) string {
 	if ip := net.ParseIP(host); ip != nil {
 		if ip.IsLoopback() {
-			return "127.0.0.1"
+			return "localhost"
 		}
-	} else if host == "localhost" {
-		return "127.0.0.1"
 	}
 	return host
 }
@@ -141,7 +135,8 @@ func testInstance(ctx context.Context, address string, port int) (up, cancelled 
 	go func() {
 		client := &http.Client{Timeout: time.Second * 10}
 		for i := 0; i < 300; i++ {
-			url := fmt.Sprintf("http://%s:%d/_api/version", address, port)
+			addr := net.JoinHostPort(address, strconv.Itoa(port))
+			url := fmt.Sprintf("http://%s/_api/version", addr)
 			r, e := client.Get(url)
 			if e == nil && r != nil && r.StatusCode == 200 {
 				instanceUp <- true
@@ -223,11 +218,12 @@ func (s *Service) makeBaseArgs(myHostDir, myContainerDir string, myAddress strin
 	if s.ServerThreads != 0 {
 		args = append(args, "--server.threads", strconv.Itoa(s.ServerThreads))
 	}
+	myTCPURL := "tcp://" + net.JoinHostPort(myAddress, myPort)
 	switch mode {
 	case "agent":
 		args = append(args,
 			"--agency.activate", "true",
-			"--agency.my-address", fmt.Sprintf("tcp://%s:%s", myAddress, myPort),
+			"--agency.my-address", myTCPURL,
 			"--agency.size", strconv.Itoa(s.AgencySize),
 			"--agency.supervision", "true",
 			"--foxx.queues", "false",
@@ -237,23 +233,23 @@ func (s *Service) makeBaseArgs(myHostDir, myContainerDir string, myAddress strin
 			if p.HasAgent && p.ID != s.ID {
 				args = append(args,
 					"--agency.endpoint",
-					fmt.Sprintf("tcp://%s:%d", p.Address, s.MasterPort+p.PortOffset+portOffsetAgent),
+					fmt.Sprintf("tcp://%s", net.JoinHostPort(p.Address, strconv.Itoa(s.MasterPort+p.PortOffset+portOffsetAgent))),
 				)
 			}
 		}
 	case "dbserver":
 		args = append(args,
-			"--cluster.my-address", fmt.Sprintf("tcp://%s:%s", myAddress, myPort),
+			"--cluster.my-address", myTCPURL,
 			"--cluster.my-role", "PRIMARY",
-			"--cluster.my-local-info", fmt.Sprintf("tcp://%s:%s", myAddress, myPort),
+			"--cluster.my-local-info", myTCPURL,
 			"--foxx.queues", "false",
 			"--server.statistics", "true",
 		)
 	case "coordinator":
 		args = append(args,
-			"--cluster.my-address", fmt.Sprintf("tcp://%s:%s", myAddress, myPort),
+			"--cluster.my-address", myTCPURL,
 			"--cluster.my-role", "COORDINATOR",
-			"--cluster.my-local-info", fmt.Sprintf("tcp://%s:%s", myAddress, myPort),
+			"--cluster.my-local-info", myTCPURL,
 			"--foxx.queues", "true",
 			"--server.statistics", "true",
 		)
@@ -263,7 +259,7 @@ func (s *Service) makeBaseArgs(myHostDir, myContainerDir string, myAddress strin
 			p := s.myPeers.Peers[i]
 			args = append(args,
 				"--cluster.agency-endpoint",
-				fmt.Sprintf("tcp://%s:%d", p.Address, s.MasterPort+p.PortOffset+portOffsetAgent),
+				fmt.Sprintf("tcp://%s", net.JoinHostPort(p.Address, strconv.Itoa(s.MasterPort+p.PortOffset+portOffsetAgent))),
 			)
 		}
 	}

--- a/service/peers.go
+++ b/service/peers.go
@@ -1,5 +1,12 @@
 package service
 
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
 type Peer struct {
 	ID         string // Unique of of the peer
 	Address    string // IP address of arangodb peer server
@@ -7,6 +14,13 @@ type Peer struct {
 	PortOffset int    // Offset to add to base ports for the various servers (agent, coordinator, dbserver)
 	DataDir    string // Directory holding my data
 	HasAgent   bool   // If set, this peer is running an agent
+}
+
+// CreateStarterURL creates a URL to the relative path to the starter on this peer.
+func (p Peer) CreateStarterURL(relPath string) string {
+	addr := net.JoinHostPort(p.Address, strconv.Itoa(p.Port))
+	relPath = strings.TrimPrefix(relPath, "/")
+	return fmt.Sprintf("http://%s/%s", addr, relPath)
 }
 
 // Peer information.

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -243,7 +244,7 @@ func (r *dockerRunner) CreateStartArangodbCommand(index int, masterIP string, ma
 	addr := masterIP
 	hostPort := 4000 + (portOffsetIncrement * (index - 1))
 	if masterPort != "" {
-		addr = addr + ":" + masterPort
+		addr = net.JoinHostPort(addr, masterPort)
 		masterPortI, _ := strconv.Atoi(masterPort)
 		hostPort = masterPortI + (portOffsetIncrement * (index - 1))
 	}

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,7 +81,7 @@ func (r *processRunner) CreateStartArangodbCommand(index int, masterIP string, m
 	}
 	addr := masterIP
 	if masterPort != "" {
-		addr = addr + ":" + masterPort
+		addr = net.JoinHostPort(addr, masterPort)
 	}
 	return fmt.Sprintf("arangodb --dataDir=./db%d --join %s", index, addr)
 }

--- a/service/server.go
+++ b/service/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 type HelloRequest struct {
@@ -59,7 +60,7 @@ func (s *Service) startHTTPServer() {
 			s.log.Fatalf("Failed to get HTTP port info: %#v", err)
 		}
 		addr := fmt.Sprintf("0.0.0.0:%d", containerPort)
-		s.log.Infof("Listening on %s (%s:%d)", addr, s.OwnAddress, hostPort)
+		s.log.Infof("Listening on %s (%s)", addr, net.JoinHostPort(s.OwnAddress, strconv.Itoa(hostPort)))
 		if err := http.ListenAndServe(addr, nil); err != nil {
 			s.log.Errorf("Failed to listen on %s: %v", addr, err)
 		}

--- a/service/slave.go
+++ b/service/slave.go
@@ -31,7 +31,8 @@ func (s *Service) startSlave(peerAddress string, runner Runner) {
 		})
 		buf := bytes.Buffer{}
 		buf.Write(b)
-		r, e := http.Post(fmt.Sprintf("http://%s:%d/hello", peerAddress, masterPort), "application/json", &buf)
+		addr := net.JoinHostPort(peerAddress, strconv.Itoa(masterPort))
+		r, e := http.Post(fmt.Sprintf("http://%s/hello", addr), "application/json", &buf)
 		if e != nil {
 			s.log.Infof("Cannot start because of error from master: %v", e)
 			time.Sleep(time.Second)
@@ -76,7 +77,7 @@ func (s *Service) startSlave(peerAddress string, runner Runner) {
 		}
 		time.Sleep(time.Second)
 		master := s.myPeers.Peers[0]
-		r, err := http.Get(fmt.Sprintf("http://%s:%d/hello", master.Address, master.Port))
+		r, err := http.Get(master.CreateStarterURL("/hello"))
 		if err != nil {
 			s.log.Errorf("Failed to connect to master: %v", err)
 			time.Sleep(time.Second * 2)
@@ -97,7 +98,7 @@ func (s *Service) sendMasterGoodbye() error {
 		// I'm the master, do nothing
 		return nil
 	}
-	u := fmt.Sprintf("http://%s:%d/goodbye", master.Address, master.Port)
+	u := master.CreateStarterURL("/goodbye")
 	s.log.Infof("Saying goodbye to master at %s", u)
 	req := GoodbyeRequest{SlaveID: s.ID}
 	data, err := json.Marshal(req)

--- a/service/slave.go
+++ b/service/slave.go
@@ -18,7 +18,8 @@ func (s *Service) startSlave(peerAddress string, runner Runner) {
 		masterPort, _ = strconv.Atoi(port)
 	}
 	for {
-		s.log.Infof("Contacting master %s:%d...", peerAddress, masterPort)
+		masterAddr := net.JoinHostPort(peerAddress, strconv.Itoa(masterPort))
+		s.log.Infof("Contacting master %s...", masterAddr)
 		_, hostPort, err := s.getHTTPServerPort()
 		if err != nil {
 			s.log.Fatalf("Failed to get HTTP server port: %#v", err)
@@ -31,8 +32,7 @@ func (s *Service) startSlave(peerAddress string, runner Runner) {
 		})
 		buf := bytes.Buffer{}
 		buf.Write(b)
-		addr := net.JoinHostPort(peerAddress, strconv.Itoa(masterPort))
-		r, e := http.Post(fmt.Sprintf("http://%s/hello", addr), "application/json", &buf)
+		r, e := http.Post(fmt.Sprintf("http://%s/hello", masterAddr), "application/json", &buf)
 		if e != nil {
 			s.log.Infof("Cannot start because of error from master: %v", e)
 			time.Sleep(time.Second)


### PR DESCRIPTION
Fixes #13 

This PR correctly formats URL's with IPv6 addresses.
It also changes the hostname normalization such that all localhost addresses are called "localhost" instead of "127.0.0.1" to cope with local IPv4 / IPv6 mixings