### PR TITLE
Adding SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,65 @@ Usually one would use the Docker image `arangodb/arangodb`.
 `containerName` is the name of a Docker container that is used to run the
 executable. This argument is required when running the executable in docker.
 
+Authentication options
+----------------------
+
+The arango starter by default creates a cluster that uses no authentication.
+
+To create a cluster that uses authentication, create a file containing a random JWT secret (single line)
+and pass it through the `--jwtSecretFile` option.
+
+For example:
+
+```
+echo "MakeThisSecretMuchStronger" > jwtSecret 
+arangodb --jwtSecretFile=./jwtSecret
+```
+
+All starters used in the cluster must have the same JWT secret.
+
+SSL options
+-----------
+
+The arango starter by default creates a cluster that uses no unencrypted connections (no SSL).
+
+To create a cluster that uses encrypted connections, you can use an existing server key file 
+or let the starter create one for you.
+
+To use an existing server key file use the `--sslKeyFile` option like this:
+
+```
+arangodb --sslKeyFile=myServer.key
+```
+
+Go to the [SSL manual](https://docs.arangodb.com/3.1/Manual/Administration/Configuration/SSL.html) for more
+information on how to create a server key file.
+
+To let the starter created a self-signed server key file, use the `--sslAutoKeyFile` option like this:
+
+```
+arangodb --sslAutoKeyFile
+```
+
+All starters used to make a cluster must be using SSL or not.
+You cannot have one starter using SSL and another not using SSL.
+
+Note that all starters can use different server key files.
+
+Additional SSL options:
+
+* `--sslCAFile path`
+
+Configure the servers to require a client certificate in their communication to the servers using the CA certificate in a file with given path.
+
+* `--sslAutoServerName name` 
+
+name of the server that will be used in the self-signed certificate created by the `--sslAutoKeyFile` option.
+
+* `--sslAutoOrganization name` 
+
+name of the server that will be used in the self-signed certificate created by the `--sslAutoKeyFile` option.
+
 Esoteric options
 ----------------
 
@@ -222,8 +281,6 @@ Future plans
 
 * bundle this program with the usual distribution
 * make port usage configurable
-* support SSL
-* support authentication
 
 Technical explanation as to what happens
 ----------------------------------------

--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ var (
 	serverThreads        int
 	allPortOffsetsUnique bool
 	jwtSecretFile        string
+	sslKeyFile           string
+	sslCAFile            string
 	dockerEndpoint       string
 	dockerImage          string
 	dockerUser           string
@@ -82,6 +84,8 @@ func init() {
 	f.BoolVar(&dockerPrivileged, "dockerPrivileged", false, "Run containers with --privileged")
 	f.BoolVar(&allPortOffsetsUnique, "uniquePortOffsets", false, "If set, all peers will get a unique port offset. If false (default) only portOffset+peerAddress pairs will be unique.")
 	f.StringVar(&jwtSecretFile, "jwtSecretFile", "", "name of a plain text file containing a JWT secret used for server authentication")
+	f.StringVar(&sslKeyFile, "sslKeyFile", "", "path of a PEM encoded file containing a server certificate + private key")
+	f.StringVar(&sslCAFile, "sslCAFile", "", "path of a PEM encoded file containing a CA certificate used for client authentication")
 }
 
 // handleSignal listens for termination signals and stops this process onup termination.
@@ -227,6 +231,8 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 		ServerThreads:        serverThreads,
 		AllPortOffsetsUnique: allPortOffsetsUnique,
 		JwtSecret:            jwtSecret,
+		SslKeyFile:           sslKeyFile,
+		SslCAFile:            sslCAFile,
 		RunningInDocker:      os.Getenv("RUNNING_IN_DOCKER") == "true",
 		DockerContainer:      dockerContainer,
 		DockerEndpoint:       dockerEndpoint,

--- a/main.go
+++ b/main.go
@@ -50,6 +50,9 @@ var (
 	allPortOffsetsUnique bool
 	jwtSecretFile        string
 	sslKeyFile           string
+	sslAutoKeyFile       bool
+	sslAutoServerName    string
+	sslAutoOrganization  string
 	sslCAFile            string
 	dockerEndpoint       string
 	dockerImage          string
@@ -86,6 +89,9 @@ func init() {
 	f.StringVar(&jwtSecretFile, "jwtSecretFile", "", "name of a plain text file containing a JWT secret used for server authentication")
 	f.StringVar(&sslKeyFile, "sslKeyFile", "", "path of a PEM encoded file containing a server certificate + private key")
 	f.StringVar(&sslCAFile, "sslCAFile", "", "path of a PEM encoded file containing a CA certificate used for client authentication")
+	f.BoolVar(&sslAutoKeyFile, "sslAutoKeyFile", false, "If set, a self-signed certificate will be created and used as --sslKeyFile")
+	f.StringVar(&sslAutoServerName, "sslAutoServerName", "", "Server name put into self-signed certificate. See --sslAutoKeyFile")
+	f.StringVar(&sslAutoOrganization, "sslAutoOrganization", "ArangoDB", "Organization name put into self-signed certificate. See --sslAutoKeyFile")
 }
 
 // handleSignal listens for termination signals and stops this process onup termination.
@@ -206,6 +212,30 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 			log.Fatalf("Failed to read JWT secret file '%s': %v", jwtSecretFile, err)
 		}
 		jwtSecret = strings.TrimSpace(string(content))
+	}
+
+	// Auto create key file (if needed)
+	if sslAutoKeyFile {
+		if sslKeyFile != "" {
+			log.Fatalf("Cannot specify both --sslAutoKeyFile and --sslKeyFile")
+		}
+		hosts := []string{"arangod.server"}
+		if sslAutoServerName != "" {
+			hosts = []string{sslAutoServerName}
+		}
+		if ownAddress != "" {
+			hosts = append(hosts, ownAddress)
+		}
+		keyFile, err := service.CreateCertificate(service.CreateCertificateOptions{
+			Hosts:        hosts,
+			RSABits:      2048,
+			Organization: sslAutoOrganization,
+		}, dataDir)
+		if err != nil {
+			log.Fatalf("Failed to create keyfile: %v", err)
+		}
+		sslKeyFile = keyFile
+		log.Infof("Using self-signed certificate: %s", sslKeyFile)
 	}
 
 	// Interrupt signal:

--- a/service/certificate.go
+++ b/service/certificate.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"time"
+)
+
+// CreateCertificateOptions configures how to create a certificate.
+type CreateCertificateOptions struct {
+	Hosts        []string // Host names and/or IP addresses
+	ValidFor     time.Duration
+	RSABits      int
+	Organization string
+}
+
+const (
+	defaultValidFor = time.Hour * 24 * 365 // 1year
+)
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	default:
+		return nil
+	}
+}
+
+// CreateCertificate creates a self-signed certificate according to the given configuration.
+// The resulting certificate + private key will be written into a single file in the given folder.
+// The path of that single file is returned.
+func CreateCertificate(options CreateCertificateOptions, folder string) (string, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, options.RSABits)
+	if err != nil {
+		return "", maskAny(err)
+	}
+
+	notBefore := time.Now()
+	if options.ValidFor == 0 {
+		options.ValidFor = defaultValidFor
+	}
+	notAfter := notBefore.Add(options.ValidFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return "", maskAny(fmt.Errorf("failed to generate serial number: %v", err))
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{options.Organization},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, h := range options.Hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	// Create the certificate
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		return "", maskAny(fmt.Errorf("Failed to create certificate: %v", err))
+	}
+
+	// Write the certificate to disk
+	f, err := ioutil.TempFile(folder, "key-")
+	if err != nil {
+		return "", maskAny(err)
+	}
+	defer f.Close()
+	// Public key
+	pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	// Private key
+	pem.Encode(f, pemBlockForKey(priv))
+
+	return f.Name(), nil
+}

--- a/service/peers.go
+++ b/service/peers.go
@@ -14,6 +14,7 @@ type Peer struct {
 	PortOffset int    // Offset to add to base ports for the various servers (agent, coordinator, dbserver)
 	DataDir    string // Directory holding my data
 	HasAgent   bool   // If set, this peer is running an agent
+	IsSecure   bool   // If set, servers started by this peer are using an SSL connection
 }
 
 // CreateStarterURL creates a URL to the relative path to the starter on this peer.

--- a/service/slave.go
+++ b/service/slave.go
@@ -29,6 +29,7 @@ func (s *Service) startSlave(peerAddress string, runner Runner) {
 			SlaveID:      s.ID,
 			SlaveAddress: s.OwnAddress,
 			SlavePort:    hostPort,
+			IsSecure:     s.IsSecure(),
 		})
 		buf := bytes.Buffer{}
 		buf.Write(b)


### PR DESCRIPTION
fixes #11

This PR adds options to create a cluster that uses SSL connections (instead of plain text connections).

See README.md for how to use it.