### PR TITLE
Show user friendly address to reach the coordinator

### DIFF
--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -442,11 +442,14 @@ func (s *Service) startRunning(runner Runner) {
 								}
 							} else {
 								scheme := "http"
+								arangoshScheme := "tcp"
 								if myPeer.IsSecure {
 									scheme = "https"
+									arangoshScheme = "ssl"
 								}
 								ip := myPeer.Address
-								s.log.Infof("%s can be accessed via %s://%s:%d.", mode, scheme, ip, hostPort)
+								s.log.Infof("Your cluster can now be accessed with a browser at `%s://%s:%d` or", scheme, ip, hostPort)
+								s.log.Infof("using `arangosh --server.endpoint %s://%s:%d`.", arangoshScheme, ip, hostPort)
 							}
 						}
 					} else {

--- a/service/runner.go
+++ b/service/runner.go
@@ -32,6 +32,8 @@ type Process interface {
 	ContainerID() string
 	// ContainerIP returns the IP address of the docker container that runs the process.
 	ContainerIP() string
+	// HostPort returns the port on the host that is used to access the given port of the process.
+	HostPort(containerPort int) (int, error)
 
 	// Wait until the process has terminated
 	Wait()

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -370,6 +370,20 @@ func (p *dockerContainer) ContainerIP() string {
 	return ""
 }
 
+// HostPort returns the port on the host that is used to access the given port of the process.
+func (p *dockerContainer) HostPort(containerPort int) (int, error) {
+	if hostConfig := p.container.HostConfig; hostConfig != nil {
+		if hostConfig.NetworkMode == "host" {
+			return containerPort, nil
+		}
+		dockerPort := docker.Port(fmt.Sprintf("%d/tcp", containerPort))
+		if binding, ok := hostConfig.PortBindings[dockerPort]; ok && len(binding) > 0 {
+			return strconv.Atoi(binding[0].HostPort)
+		}
+	}
+	return 0, fmt.Errorf("Cannot find port mapping.")
+}
+
 func (p *dockerContainer) Wait() {
 	p.client.WaitContainer(p.container.ID)
 }

--- a/service/runner_process.go
+++ b/service/runner_process.go
@@ -111,6 +111,11 @@ func (p *process) ContainerIP() string {
 	return ""
 }
 
+// HostPort returns the port on the host that is used to access the given port of the process.
+func (p *process) HostPort(containerPort int) (int, error) {
+	return containerPort, nil
+}
+
 func (p *process) Wait() {
 	if proc := p.p; proc != nil {
 		p.log.Debugf("Waiting on %d", proc.Pid)


### PR DESCRIPTION
fixes #23 

# Sample output

```
2017/04/18 07:19:36 dbserver up and running.
2017/04/18 07:19:37 coordinator up and running.
2017/04/18 07:19:37 Your cluster can now be accessed with a browser at `http://localhost:4002` or
2017/04/18 07:19:37 using `arangosh --server.endpoint tcp://localhost:4002`.
```

Note: In some container configuration there is not host mapping of the port exposed by the coordinator. In that case you're notified of that (and no URL is given)