### PR TITLE
Custom network namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,22 @@ of the process in the Docker container.
 `endpoint` is the URL used to reach the docker host. This is needed to run 
 the executable in docker. The default value is "unix:///var/run/docker.sock".
 
-* `--dockerNetHost bool`
+* `--dockerNetworkMode mode`
 
-If `dockerNetHost` is set, all docker container will be started 
-with the `--net=host` option.
+If `dockerNetworkMode` is set, all docker container will be started 
+with the `--net=<mode>` option.
 
 * `--dockerPrivileged bool`
 
 If `dockerPrivileged` is set, all docker container will be started 
 with the `--privileged` option turned on.
+
+* `--dockerNetHost bool` (deprecated)
+
+If `dockerNetHost` is set, all docker container will be started 
+with the `--net=host` option.
+
+This option is deprecated, use `--dockerNetworkMode=host` instead.
 
 HTTP API
 --------

--- a/service/docker.go
+++ b/service/docker.go
@@ -3,34 +3,36 @@ package service
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
 
 // findDockerExposedAddress looks up the external port number to which the given
 // port is mapped onto for the given container.
-func findDockerExposedAddress(dockerEndpoint, containerName string, port int) (hostPort int, isNetHost bool, err error) {
+func findDockerExposedAddress(dockerEndpoint, containerName string, port int) (hostPort int, isNetHost bool, networkMode string, err error) {
 	client, err := docker.NewClient(dockerEndpoint)
 	if err != nil {
-		return 0, false, maskAny(err)
+		return 0, false, "", maskAny(err)
 	}
 	container, err := client.InspectContainer(containerName)
 	if err != nil {
-		return 0, false, maskAny(err)
+		return 0, false, "", maskAny(err)
 	}
-	isNetHost = container.HostConfig.NetworkMode == "host"
+	networkMode = container.HostConfig.NetworkMode
+	isNetHost = networkMode == "host" || strings.HasPrefix(networkMode, "container:")
 	if isNetHost {
 		// There is no port mapping for `--net=host`
-		return port, isNetHost, nil
+		return port, isNetHost, networkMode, nil
 	}
 	dockerPort := docker.Port(fmt.Sprintf("%d/tcp", port))
 	bindings, ok := container.NetworkSettings.Ports[dockerPort]
 	if !ok || len(bindings) == 0 {
-		return 0, isNetHost, maskAny(fmt.Errorf("Cannot find port binding for TCP port %d", port))
+		return 0, isNetHost, networkMode, maskAny(fmt.Errorf("Cannot find port binding for TCP port %d", port))
 	}
 	hostPort, err = strconv.Atoi(bindings[0].HostPort)
 	if err != nil {
-		return 0, isNetHost, maskAny(err)
+		return 0, isNetHost, networkMode, maskAny(err)
 	}
-	return hostPort, isNetHost, nil
+	return hostPort, isNetHost, networkMode, nil
 }


### PR DESCRIPTION
This PR adds support for running starters (and the started servers) in custom network namespaces.

This can be useful to run an entire cluster locally in its own (separated) network namespace.

When running the started in docker, it will automatically pick up network modes like `host` or `container:some-container-id`