### PR TITLE
Change port offsets of servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes from version 0.6.0 to master 
+
+- Changed port offsets of servers. Coordinator -> 1, DBServer -> 2, Agent -> 3.
+
 # Changes from version 0.4.1 to 0.5.0
 
 - Added authentication support (#10)

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ its data directory, starts up its `arangod` instances again (with their
 data) and they join the cluster.
 
 All network addresses are discovered from the HTTP communication between
-the `arangodb` instances. The ports used 4001(/4006/4011) for the agent, 
-4002(/4007/4012) for the coordinator, 4003(/4008/4013) for the DBserver) 
+the `arangodb` instances. The ports used 4001(/4006/4011) for the coordinator, 
+4002(/4007/4012) for the DBserver, 4003(/4008/4013) for the agent) 
 need to be free. If more than one instance of an `arangodb` are started 
 on the same machine, the second will increase all these port numbers by 5 and so on.
 

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -108,9 +108,9 @@ const (
 )
 
 const (
-	portOffsetAgent       = 1
-	portOffsetCoordinator = 2
-	portOffsetDBServer    = 3
+	portOffsetCoordinator = 1
+	portOffsetDBServer    = 2
+	portOffsetAgent       = 3
 	portOffsetIncrement   = 5 // {our http server, agent, coordinator, dbserver, reserved}
 )
 


### PR DESCRIPTION
Offsets of servers started by the starter have changed to align with their importance.
Coordinator first, dbserver second, agent third.