### PR TITLE
Changing default base port to 8528

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changes from version 0.6.0 to master 
 
+- Changed default master port from 4000 to 8528. That results in a coordinator/single server to be available on well known port 8529.
 - Added `--mode=single` argument, used to start a single server database instead of a cluster (#28)
 - Starter will check availability of TCP ports (both its own HTTP API & Arangod Servers) (#35)
 - Docker container created by the started are given the label `created-by=arangodb-starter`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Max Neunhoeffer <max@arangodb.com>
 
 COPY bin/linux/amd64/arangodb /app/
 
-EXPOSE 4000 
+EXPOSE 8528 
 
 VOLUME /data
 

--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ On host A:
 arangodb
 ```
 
-This will use port 4000 to wait for colleagues (3 are needed for a
+This will use port 8528 to wait for colleagues (3 are needed for a
 resilient agency). On host B: (can be the same as A):
 
 ```
 arangodb --join A
 ```
 
-This will contact A on port 4000 and register. On host C: (can be same
+This will contact A on port 8528 and register. On host C: (can be same
 as A or B):
 
 ```
 arangodb --join A
 ```
 
-This will contact A on port 4000 and register.
+This will contact A on port 8528 and register.
 
 From the moment on when 3 have joined, each will fire up an agent, a 
 coordinator and a dbserver and the cluster is up. Ports are shown on
@@ -77,7 +77,7 @@ commands.
 ```
 export IP=<IP of docker host>
 docker volume create arangodb1
-docker run -it --name=adb1 --rm -p 4000:4000 \
+docker run -it --name=adb1 --rm -p 8528:8528 \
     -v arangodb1:/data \
     -v /var/run/docker.sock:/var/run/docker.sock \
     arangodb/arangodb-starter \
@@ -126,7 +126,7 @@ use the normal docker arguments, combined with `--mode=single`.
 ```
 export IP=<IP of docker host>
 docker volume create arangodb
-docker run -it --name=adb --rm -p 4000:4000 \
+docker run -it --name=adb --rm -p 8528:8528 \
     -v arangodb:/data \
     -v /var/run/docker.sock:/var/run/docker.sock \
     arangodb/arangodb-starter \
@@ -254,7 +254,7 @@ Esoteric options
 
 * `--masterPort int`
 
-port for arangodb master (default 4000).
+port for arangodb master (default 8528).
 
 This is the port used for communication of the `arangodb` instances
 amongst each other.
@@ -350,7 +350,7 @@ Technical explanation as to what happens
 ----------------------------------------
 
 The procedure is essentially that the first instance of `arangodb` (aka
-the "master") offers an HTTP service on port 4000 for peers to register.
+the "master") offers an HTTP service on port 8528 for peers to register.
 Every instance that registers becomes a slave. As soon as there are
 `agencySize` peers, every instance of `arangodb` starts up an agent (if
 it is one of the first 3), a DBserver, and a coordinator. The necessary
@@ -364,13 +364,13 @@ its data directory, starts up its `arangod` instances again (with their
 data) and they join the cluster.
 
 All network addresses are discovered from the HTTP communication between
-the `arangodb` instances. The ports used 4001(/4006/4011) for the coordinator, 
-4002(/4007/4012) for the DBserver, 4003(/4008/4013) for the agent) 
+the `arangodb` instances. The ports used 8529(/8534/8539) for the coordinator, 
+8530(/8535/8540) for the DBserver, 8531(/8536/8537) for the agent) 
 need to be free. If more than one instance of an `arangodb` are started 
 on the same machine, the second will increase all these port numbers by 5 and so on.
 
 In case the executable is running in Docker, it will use the Docker 
-API to retrieve the port number of the Docker host to which the 4000 port 
+API to retrieve the port number of the Docker host to which the 8528 port 
 number is mapped. The containers started by the executable will all 
 map the port they use to the exact same host port.
 

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func init() {
 	f.StringVar(&id, "id", "", "Unique identifier of this peer")
 	f.StringVar(&arangodPath, "arangod", "/usr/sbin/arangod", "Path of arangod")
 	f.StringVar(&arangodJSPath, "jsDir", "/usr/share/arangodb3/js", "Path of arango JS")
-	f.IntVar(&masterPort, "masterPort", 4000, "Port to listen on for other arangodb's to join")
+	f.IntVar(&masterPort, "masterPort", service.DefaultMasterPort, "Port to listen on for other arangodb's to join")
 	f.StringVar(&rrPath, "rr", "", "Path of rr")
 	f.BoolVar(&startCoordinator, "startCoordinator", true, "should a coordinator instance be started")
 	f.BoolVar(&startDBserver, "startDBserver", true, "should a dbserver instance be started")

--- a/service/arangodb.go
+++ b/service/arangodb.go
@@ -44,6 +44,10 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+const (
+	DefaultMasterPort = 8528
+)
+
 // Config holds all configuration for a single service.
 type Config struct {
 	ID                   string // Unique identifier of this peer

--- a/service/runner_docker.go
+++ b/service/runner_docker.go
@@ -269,7 +269,7 @@ func (r *dockerRunner) pullImage(image string) error {
 
 func (r *dockerRunner) CreateStartArangodbCommand(index int, masterIP string, masterPort string) string {
 	addr := masterIP
-	hostPort := 4000 + (portOffsetIncrement * (index - 1))
+	hostPort := DefaultMasterPort + (portOffsetIncrement * (index - 1))
 	if masterPort != "" {
 		addr = net.JoinHostPort(addr, masterPort)
 		masterPortI, _ := strconv.Atoi(masterPort)
@@ -277,7 +277,7 @@ func (r *dockerRunner) CreateStartArangodbCommand(index int, masterIP string, ma
 	}
 	var netArgs string
 	if r.networkMode == "" || r.networkMode == "default" {
-		netArgs = fmt.Sprintf("-p %d:4000", hostPort)
+		netArgs = fmt.Sprintf("-p %d:%d", hostPort, DefaultMasterPort)
 	} else {
 		netArgs = fmt.Sprintf("--net=%s", r.networkMode)
 	}

--- a/service/setup_config.go
+++ b/service/setup_config.go
@@ -32,7 +32,7 @@ import (
 const (
 	// SetupConfigVersion is the semantic version of the process that created this.
 	// If the structure of SetupConfigFile (or any underlying fields) or its semantics change, you must increase this version.
-	SetupConfigVersion = "0.2.0"
+	SetupConfigVersion = "0.2.1"
 	setupFileName      = "setup.json"
 )
 

--- a/test/docker_cluster_default_test.go
+++ b/test/docker_cluster_default_test.go
@@ -38,7 +38,7 @@ func TestDockerClusterDefault(t *testing.T) {
 	}
 	/*
 		docker volume create arangodb1
-		docker run -it --name=adb1 --rm -p 4000:4000 \
+		docker run -it --name=adb1 --rm -p 8528:8528 \
 			-v arangodb1:/data \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			arangodb/arangodb-starter \

--- a/test/docker_cluster_local_test.go
+++ b/test/docker_cluster_local_test.go
@@ -38,7 +38,7 @@ func TestDockerClusterLocal(t *testing.T) {
 	}
 	/*
 		docker volume create arangodb1
-		docker run -it --name=adb1 --rm -p 4000:4000 \
+		docker run -it --name=adb1 --rm -p 8528:8528 \
 			-v arangodb1:/data \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			arangodb/arangodb-starter \

--- a/test/docker_single_test.go
+++ b/test/docker_single_test.go
@@ -38,7 +38,7 @@ func TestDockerSingle(t *testing.T) {
 	}
 	/*
 		docker volume create arangodb1
-		docker run -it --name=adb1 --rm -p 4000:4000 \
+		docker run -it --name=adb1 --rm -p 8528:8528 \
 			-v arangodb1:/data \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			arangodb/arangodb-starter \
@@ -91,7 +91,7 @@ func TestDockerSingleAutoKeyFile(t *testing.T) {
 	}
 	/*
 		docker volume create arangodb1
-		docker run -it --name=adb1 --rm -p 4000:4000 \
+		docker run -it --name=adb1 --rm -p 8528:8528 \
 			-v arangodb1:/data \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			arangodb/arangodb-starter \

--- a/test/server_util.go
+++ b/test/server_util.go
@@ -32,10 +32,11 @@ import (
 	"time"
 
 	"github.com/arangodb/ArangoDBStarter/client"
+	"github.com/arangodb/ArangoDBStarter/service"
 )
 
 const (
-	basePort = 4000
+	basePort = service.DefaultMasterPort
 )
 
 var (


### PR DESCRIPTION
Fixes #24 

Changed default master port from 4000 to 8528. That results in a coordinator/single server to be available on well known port 8529.